### PR TITLE
include `<meta>` tags for Origin-Trial tokens (valid for `*.github.io`) (fixes issue #101)

### DIFF
--- a/Assets/WebGLTemplates/WebVR/index.html
+++ b/Assets/WebGLTemplates/WebVR/index.html
@@ -3,6 +3,10 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- Origin Trial Token, feature = Generic Sensors, origin = https://github.io, expires = 2018-03-19 -->
+    <meta http-equiv="origin-trial" data-feature="Generic Sensors" data-expires="2018-03-19" content="At8CasvpWmrmsQvZrjptKgHxir6IWt+LAbEGvH+ib3bPilNj2zQl4kc/rR3EI3Abxd+7FkspW7XchApVUULWdgUAAABQeyJvcmlnaW4iOiJodHRwczovL2dpdGh1Yi5pbzo0NDMiLCJmZWF0dXJlIjoiR2VuZXJpY1NlbnNvciIsImV4cGlyeSI6MTUyMTQ5NTgwMX0=">
+    <!-- Origin Trial Token, feature = WebVR (For Chrome M62+), origin = https://github.io, expires = 2018-03-19 -->
+    <meta http-equiv="origin-trial" data-feature="WebVR (For Chrome M62+)" data-expires="2018-03-19" content="AlTelBgEe1Z8i9wYmPx9Xsqcl+oAXHt3y0xx8OYukz4C3oSg08G+UNCSZ1YVW6FOgK2GG2j1Vz9VZsGtwbHxjQsAAABOeyJvcmlnaW4iOiJodHRwczovL2dpdGh1Yi5pbzo0NDMiLCJmZWF0dXJlIjoiV2ViVlIxLjFNNjIiLCJleHBpcnkiOjE1MjE0OTU4MDF9">
     <title>%UNITY_CUSTOM_NAME% | %UNITY_WEB_NAME%</title>
     <meta name="description" content="%UNITY_CUSTOM_DESCRIPTION%">
     <link rel="icon" href="favicon.ico">


### PR DESCRIPTION
Fix #101 

can you test update your `caseyee.github.io` `gh-pages` and test the following (with WebVR flag off but Gamepad Extensions still enabled)?

- Chrome Canary for Windows
- Chrome for Android

thanks, mate!
