### PR TITLE
disable Telemetry for localhost/non-HTTPS origins (fixes issue #223)

### DIFF
--- a/Assets/WebGLTemplates/WebVR/lib/telemetry.js
+++ b/Assets/WebGLTemplates/WebVR/lib/telemetry.js
@@ -19,6 +19,29 @@
  * this does not conflict with requirement #2.
  */
 
+var endsWith = function (str, suffix) {
+  if (typeof String.prototype.endsWith === 'function') {
+    return String.prototype.endsWith.call(str, suffix);
+  }
+  return str.indexOf(suffix, str.length - suffix.length) !== -1;
+};
+
+// Check if the origin looks like a production, non-development host (i.e., public and served over HTTPS).
+// Relevant reading: https://w3c.github.io/webappsec-secure-contexts/#localhost
+var isSecureOrigin = onlyOnce(function (win) {
+  return !(
+    win.isSecureContext === false ||
+    win.location.protocol === 'http:' ||
+    win.location.hostname === 'localhost' ||
+    endsWith(win.location.hostname, '.localhost') ||
+    win.location.hostname === '127.0.1' ||
+    win.location.hostname === '0.0.0.0' ||
+    win.location.host.indexOf('::1') === 0 ||
+    endsWith(win.location.hostname, '.ngrok.io') ||
+    endsWith(win.location.hostname, '.localtunnel.me')
+  );
+});
+
 var CURRENT_VERSION = '1.1.0';
 var MOZILLA_RESEARCH_TRACKER = 'UA-77033033-6';
 
@@ -185,10 +208,12 @@ function injectScript(src, callback) {
 // IE9/IE10 uses a prefixed version while MS Edge sets the property in
 // `window` instead of `navigator`:
 // https://developer.mozilla.org/en-US/docs/Web/API/Navigator/doNotTrack#Browser_compatibility
-function doNotTrack() {
+function doNotTrack () {
+  // We also will not engage Telemetry if the origin appears to be in a development (i.e., non-production) environment.
   return navigator.doNotTrack === '1' ||
          navigator.msDoNotTrack === '1' ||
-         window.doNotTrack === '1';
+         window.doNotTrack === '1' ||
+         !isSecureOrigin(window);
 }
 
 function onlyOnce(fn) {

--- a/Assets/WebGLTemplates/WebVR/lib/telemetry.js
+++ b/Assets/WebGLTemplates/WebVR/lib/telemetry.js
@@ -28,7 +28,7 @@ var endsWith = function (str, suffix) {
 
 // Check if the origin looks like a production, non-development host (i.e., public and served over HTTPS).
 // Relevant reading: https://w3c.github.io/webappsec-secure-contexts/#localhost
-var isSecureOrigin = onlyOnce(function (win) {
+var isSecureOrigin = function (win) {
   return !(
     win.isSecureContext === false ||
     win.location.protocol === 'http:' ||
@@ -40,6 +40,17 @@ var isSecureOrigin = onlyOnce(function (win) {
     endsWith(win.location.hostname, '.ngrok.io') ||
     endsWith(win.location.hostname, '.localtunnel.me')
   );
+};
+
+// IE9/IE10 uses a prefixed version while MS Edge sets the property in
+// `window` instead of `navigator`:
+// https://developer.mozilla.org/en-US/docs/Web/API/Navigator/doNotTrack#Browser_compatibility
+var doNotTrack = onlyOnce(function () {
+  // We also will not engage Telemetry if the origin appears to be in a development (i.e., non-production) environment.
+  return navigator.doNotTrack === '1' ||
+         navigator.msDoNotTrack === '1' ||
+         window.doNotTrack === '1' ||
+         !isSecureOrigin(window);
 });
 
 var CURRENT_VERSION = '1.1.0';
@@ -203,17 +214,6 @@ function injectScript(src, callback) {
   });
   document.head.appendChild(script);
   return script;
-}
-
-// IE9/IE10 uses a prefixed version while MS Edge sets the property in
-// `window` instead of `navigator`:
-// https://developer.mozilla.org/en-US/docs/Web/API/Navigator/doNotTrack#Browser_compatibility
-function doNotTrack () {
-  // We also will not engage Telemetry if the origin appears to be in a development (i.e., non-production) environment.
-  return navigator.doNotTrack === '1' ||
-         navigator.msDoNotTrack === '1' ||
-         window.doNotTrack === '1' ||
-         !isSecureOrigin(window);
 }
 
 function onlyOnce(fn) {

--- a/Build/lib/telemetry.js
+++ b/Build/lib/telemetry.js
@@ -28,7 +28,8 @@ var endsWith = function (str, suffix) {
 
 // Check if the origin looks like a production, non-development host (i.e., public and served over HTTPS).
 // Relevant reading: https://w3c.github.io/webappsec-secure-contexts/#localhost
-var isSecureOrigin = onlyOnce(function (win) {
+var isSecureOrigin = function (win) {
+  return true;
   return !(
     win.isSecureContext === false ||
     win.location.protocol === 'http:' ||
@@ -40,6 +41,17 @@ var isSecureOrigin = onlyOnce(function (win) {
     endsWith(win.location.hostname, '.ngrok.io') ||
     endsWith(win.location.hostname, '.localtunnel.me')
   );
+};
+
+// IE9/IE10 uses a prefixed version while MS Edge sets the property in
+// `window` instead of `navigator`:
+// https://developer.mozilla.org/en-US/docs/Web/API/Navigator/doNotTrack#Browser_compatibility
+var doNotTrack = onlyOnce(function () {
+  // We also will not engage Telemetry if the origin appears to be in a development (i.e., non-production) environment.
+  return navigator.doNotTrack === '1' ||
+         navigator.msDoNotTrack === '1' ||
+         window.doNotTrack === '1' ||
+         !isSecureOrigin(window);
 });
 
 var CURRENT_VERSION = '1.1.0';
@@ -203,17 +215,6 @@ function injectScript(src, callback) {
   });
   document.head.appendChild(script);
   return script;
-}
-
-// IE9/IE10 uses a prefixed version while MS Edge sets the property in
-// `window` instead of `navigator`:
-// https://developer.mozilla.org/en-US/docs/Web/API/Navigator/doNotTrack#Browser_compatibility
-function doNotTrack () {
-  // We also will not engage Telemetry if the origin appears to be in a development (i.e., non-production) environment.
-  return navigator.doNotTrack === '1' ||
-         navigator.msDoNotTrack === '1' ||
-         window.doNotTrack === '1' ||
-         !isSecureOrigin(window);
 }
 
 function onlyOnce(fn) {

--- a/Build/lib/telemetry.js
+++ b/Build/lib/telemetry.js
@@ -19,6 +19,29 @@
  * this does not conflict with requirement #2.
  */
 
+var endsWith = function (str, suffix) {
+  if (typeof String.prototype.endsWith === 'function') {
+    return String.prototype.endsWith.call(str, suffix);
+  }
+  return str.indexOf(suffix, str.length - suffix.length) !== -1;
+};
+
+// Check if the origin looks like a production, non-development host (i.e., public and served over HTTPS).
+// Relevant reading: https://w3c.github.io/webappsec-secure-contexts/#localhost
+var isSecureOrigin = onlyOnce(function (win) {
+  return !(
+    win.isSecureContext === false ||
+    win.location.protocol === 'http:' ||
+    win.location.hostname === 'localhost' ||
+    endsWith(win.location.hostname, '.localhost') ||
+    win.location.hostname === '127.0.1' ||
+    win.location.hostname === '0.0.0.0' ||
+    win.location.host.indexOf('::1') === 0 ||
+    endsWith(win.location.hostname, '.ngrok.io') ||
+    endsWith(win.location.hostname, '.localtunnel.me')
+  );
+});
+
 var CURRENT_VERSION = '1.1.0';
 var MOZILLA_RESEARCH_TRACKER = 'UA-77033033-6';
 
@@ -185,10 +208,12 @@ function injectScript(src, callback) {
 // IE9/IE10 uses a prefixed version while MS Edge sets the property in
 // `window` instead of `navigator`:
 // https://developer.mozilla.org/en-US/docs/Web/API/Navigator/doNotTrack#Browser_compatibility
-function doNotTrack() {
+function doNotTrack () {
+  // We also will not engage Telemetry if the origin appears to be in a development (i.e., non-production) environment.
   return navigator.doNotTrack === '1' ||
          navigator.msDoNotTrack === '1' ||
-         window.doNotTrack === '1';
+         window.doNotTrack === '1' ||
+         !isSecureOrigin(window);
 }
 
 function onlyOnce(fn) {


### PR DESCRIPTION
now, if you are on `localhost` or `http://example.com` (instead of `https://example.com`), GA is not called (effectively the same behaviour as having Do-Not-Track enabled in your browser).

bonus: on page load, there are now 6 fewer requests (21 requests -> 15 requests) :smile: 👍