### PR TITLE
improve `telemetry.js` for disabling localhost/non-HTTPS origins

### DIFF
--- a/Assets/WebGLTemplates/WebVR/lib/telemetry.js
+++ b/Assets/WebGLTemplates/WebVR/lib/telemetry.js
@@ -29,9 +29,11 @@ var endsWith = function (str, suffix) {
 // Check if the origin looks like a production, non-development host (i.e., public and served over HTTPS).
 // Relevant reading: https://w3c.github.io/webappsec-secure-contexts/#localhost
 var isInsecureOrigin = function (win) {
+  // Allow HTTPS and HTTP.
+  if (win.isSecureContext === true || win.location.protocol === 'http:') {
+    return false;
+  }
   return (
-    win.isSecureContext === false ||
-    win.location.protocol === 'http:' ||
     win.location.hostname === 'localhost' ||
     endsWith(win.location.hostname, '.localhost') ||
     win.location.hostname === '127.0.1' ||

--- a/Build/lib/telemetry.js
+++ b/Build/lib/telemetry.js
@@ -29,9 +29,11 @@ var endsWith = function (str, suffix) {
 // Check if the origin looks like a production, non-development host (i.e., public and served over HTTPS).
 // Relevant reading: https://w3c.github.io/webappsec-secure-contexts/#localhost
 var isInsecureOrigin = function (win) {
+  // Allow HTTPS and HTTP.
+  if (win.isSecureContext === true || win.location.protocol === 'http:') {
+    return false;
+  }
   return (
-    win.isSecureContext === false ||
-    win.location.protocol === 'http:' ||
     win.location.hostname === 'localhost' ||
     endsWith(win.location.hostname, '.localhost') ||
     win.location.hostname === '127.0.1' ||

--- a/Build/lib/telemetry.js
+++ b/Build/lib/telemetry.js
@@ -28,9 +28,8 @@ var endsWith = function (str, suffix) {
 
 // Check if the origin looks like a production, non-development host (i.e., public and served over HTTPS).
 // Relevant reading: https://w3c.github.io/webappsec-secure-contexts/#localhost
-var isSecureOrigin = function (win) {
-  return true;
-  return !(
+var isInsecureOrigin = function (win) {
+  return (
     win.isSecureContext === false ||
     win.location.protocol === 'http:' ||
     win.location.hostname === 'localhost' ||
@@ -42,17 +41,6 @@ var isSecureOrigin = function (win) {
     endsWith(win.location.hostname, '.localtunnel.me')
   );
 };
-
-// IE9/IE10 uses a prefixed version while MS Edge sets the property in
-// `window` instead of `navigator`:
-// https://developer.mozilla.org/en-US/docs/Web/API/Navigator/doNotTrack#Browser_compatibility
-var doNotTrack = onlyOnce(function () {
-  // We also will not engage Telemetry if the origin appears to be in a development (i.e., non-production) environment.
-  return navigator.doNotTrack === '1' ||
-         navigator.msDoNotTrack === '1' ||
-         window.doNotTrack === '1' ||
-         !isSecureOrigin(window);
-});
 
 var CURRENT_VERSION = '1.1.0';
 var MOZILLA_RESEARCH_TRACKER = 'UA-77033033-6';
@@ -97,7 +85,7 @@ telemetry.start = onlyOnce(function (config) {
 setupAnalytics();
 
 function setupAnalytics() {
-  if (doNotTrack()) { return; }
+  if (isTelemetryDisabled()) { return; }
 
   window.dataLayer = window.dataLayer || [];
   window.gtag = window.gtag || function () { dataLayer.push(arguments); };
@@ -112,7 +100,7 @@ function setupAnalytics() {
 }
 
 function setupErrorLogging() {
-  if (doNotTrack()) { return; }
+  if (isTelemetryDisabled()) { return; }
 
   injectScript('https://cdn.ravenjs.com/3.22.3/console/raven.min.js', function (err) {
     if (err) {
@@ -146,13 +134,13 @@ function startAnalytics() {
 function setupPerformanceAPI(tracker) {
   telemetry.performance = {
     mark: function (name) {
-      if (doNotTrack()) { return; }
+      if (isTelemetryDisabled()) { return; }
 
       performance.mark(name);
     },
 
     measure: function (name, start, end) {
-      if (doNotTrack()) { return; }
+      if (isTelemetryDisabled()) { return; }
 
       performance.measure(name, start, end);
       var performanceEntry = performance.getEntriesByName(name)[0];
@@ -181,7 +169,7 @@ function setupPerformanceAPI(tracker) {
  * commands [2].
  */
 function configureBoundTracker(trackingId, options) {
-  if (doNotTrack()) { return NO_OP; }
+  if (isTelemetryDisabled()) { return NO_OP; }
 
   options = options || {};
   var groups = options.groups;
@@ -189,7 +177,7 @@ function configureBoundTracker(trackingId, options) {
   return trackingFunction;
 
   function trackingFunction(command, label, options) {
-    if (doNotTrack()) { return; }
+    if (isTelemetryDisabled()) { return; }
 
     options = options || {};
     if (groups) {
@@ -225,6 +213,20 @@ function onlyOnce(fn) {
     called = true;
     return returnValue;
   };
+}
+
+// IE9/IE10 uses a prefixed version while MS Edge sets the property in
+// `window` instead of `navigator`:
+// https://developer.mozilla.org/en-US/docs/Web/API/Navigator/doNotTrack#Browser_compatibility
+function doNotTrack () {
+  return navigator.doNotTrack === '1' ||
+         navigator.msDoNotTrack === '1' ||
+         window.doNotTrack === '1';
+}
+
+function isTelemetryDisabled () {
+  // Telemetry is disabled if DNT is enabled or if the origin appears to be for a development environment.
+  return doNotTrack() || isInsecureOrigin(window);
 }
 
 })(window);


### PR DESCRIPTION
this follows up on issue in #234 + PR #235 (originally issue #223), per @delapuente's feedback in https://github.com/mozilla/unity-webvr-export/pull/225#pullrequestreview-111568127
