### PR TITLE
State not retained

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,8 @@ sysinfo.txt
 
 # Visual Studio Code settings
 .vscode/*
+
+# Jetbrains Rider Code settings
+.idea
+JetBrains.meta
+Assets/Plugins/Editor/JetBrains

--- a/Assets/WebVR/Scripts/Input/FreeFlightController.cs
+++ b/Assets/WebVR/Scripts/Input/FreeFlightController.cs
@@ -37,8 +37,8 @@ public class FreeFlightController : MonoBehaviour {
 
     void Start()
     {
-        WebVRManager.OnVRChange += onVRChange;
-        WebVRManager.OnVRCapabilitiesUpdate += onVRCapabilitiesUpdate;
+        WebVRManager.Instance.OnVRChange += onVRChange;
+        WebVRManager.Instance.OnVRCapabilitiesUpdate += onVRCapabilitiesUpdate;
         originalRotation = transform.localRotation;
     }
 

--- a/Assets/WebVR/Scripts/WebVRCamera.cs
+++ b/Assets/WebVR/Scripts/WebVRCamera.cs
@@ -22,27 +22,18 @@ public class WebVRCamera : MonoBehaviour
 		PostRender ();
 	}
 
-	void Start()
-	{		
+	void OnEnable()
+	{
+		WebVRManager.Instance.OnVRChange += onVRChange;
+		WebVRManager.Instance.OnHeadsetUpdate += onHeadsetUpdate;
+		
 		cameraMain = GameObject.Find("CameraMain").GetComponent<Camera>();
 		cameraL = GameObject.Find("CameraL").GetComponent<Camera>();
 		cameraR = GameObject.Find("CameraR").GetComponent<Camera>();
-
+		
 		cameraMain.transform.Translate(new Vector3(0, DefaultHeight, 0));
 	}
-
-	void OnEnable()
-	{
-		WebVRManager.OnVRChange += onVRChange;
-		WebVRManager.OnHeadsetUpdate += onHeadsetUpdate;
-	}
 	
-	void OnDisable()
-	{
-		WebVRManager.OnVRChange -= onVRChange;
-		WebVRManager.OnHeadsetUpdate -= onHeadsetUpdate;
-	}
-
 	void Update()
 	{
 		if (vrActive)

--- a/Assets/WebVR/Scripts/WebVRCamera.cs
+++ b/Assets/WebVR/Scripts/WebVRCamera.cs
@@ -23,15 +23,24 @@ public class WebVRCamera : MonoBehaviour
 	}
 
 	void Start()
-	{
-		WebVRManager.OnVRChange += onVRChange;
-		WebVRManager.OnHeadsetUpdate += onHeadsetUpdate;
-
+	{		
 		cameraMain = GameObject.Find("CameraMain").GetComponent<Camera>();
 		cameraL = GameObject.Find("CameraL").GetComponent<Camera>();
 		cameraR = GameObject.Find("CameraR").GetComponent<Camera>();
 
 		cameraMain.transform.Translate(new Vector3(0, DefaultHeight, 0));
+	}
+
+	void OnEnable()
+	{
+		WebVRManager.OnVRChange += onVRChange;
+		WebVRManager.OnHeadsetUpdate += onHeadsetUpdate;
+	}
+	
+	void OnDisable()
+	{
+		WebVRManager.OnVRChange -= onVRChange;
+		WebVRManager.OnHeadsetUpdate -= onHeadsetUpdate;
 	}
 
 	void Update()

--- a/Assets/WebVR/Scripts/WebVRControllerManager.cs
+++ b/Assets/WebVR/Scripts/WebVRControllerManager.cs
@@ -33,7 +33,7 @@ public class WebVRControllerManager : MonoBehaviour
 
 	void Start()
 	{
-		WebVRManager.OnControllerUpdate += onControllerUpdate;
+		WebVRManager.Instance.OnControllerUpdate += onControllerUpdate;
 	}
 
 	void Awake()

--- a/Assets/WebVR/Scripts/WebVRManager.cs
+++ b/Assets/WebVR/Scripts/WebVRManager.cs
@@ -14,39 +14,42 @@ public class WebVRManager : MonoBehaviour
 
     [HideInInspector]
     public WebVRState vrState = WebVRState.NORMAL;
-    public static WebVRManager instance;
+    
+    private static WebVRManager instance;
+
+    [Tooltip("Preserve the manager across scenes changes.")]
+    public bool dontDestroyOnLoad = true;
+    
     public delegate void VRCapabilitiesUpdate(WebVRDisplayCapabilities capabilities);
-    public static event VRCapabilitiesUpdate OnVRCapabilitiesUpdate;
+    public event VRCapabilitiesUpdate OnVRCapabilitiesUpdate;
+    
     public delegate void VRChange(WebVRState state);
-    public static event VRChange OnVRChange;
+    public event VRChange OnVRChange;
+    
     public delegate void HeadsetUpdate(
         Matrix4x4 leftProjectionMatrix,
         Matrix4x4 leftViewMatrix,
         Matrix4x4 rightProjectionMatrix,
         Matrix4x4 rightViewMatrix,
         Matrix4x4 sitStandMatrix);
-    public static event HeadsetUpdate OnHeadsetUpdate;
-    public delegate void ControllerUpdate(int index, string hand, Vector3 position, Quaternion rotation, Matrix4x4 sitStand, WebVRControllerButton[] buttons);
-    public static event ControllerUpdate OnControllerUpdate;
+    public event HeadsetUpdate OnHeadsetUpdate;
+   
+    public delegate void ControllerUpdate(int index, 
+        string hand, 
+        Vector3 position, 
+        Quaternion rotation, 
+        Matrix4x4 sitStand, 
+        WebVRControllerButton[] buttons);
+    public event ControllerUpdate OnControllerUpdate;
 
-    private static bool applicationQuitting = false;
-    
     public static WebVRManager Instance {
         get
         {
-            if (applicationQuitting)
-            {
-                Debug.LogWarning("[Singleton] Instance WebVRManager '"+
-                                 "' already destroyed on application quit." +
-                                 " Won't create again - returning null. Check your OnDestroy Code");
-                return null;
-            }
-            
             if (instance == null)
             {
                 var managerInScene = FindObjectOfType<WebVRManager>();
 
-                var name = "WebVRManager (Singleton)";
+                var name = "WebVRManager";
                 
                 if (managerInScene != null)
                 {
@@ -59,17 +62,20 @@ public class WebVRManager : MonoBehaviour
                     
                     go.AddComponent<WebVRManager>();                    
                 }
-                
-                DontDestroyOnLoad(instance);
             }
             
             return instance;
         }
     }
 
-    private void OnDestroy()
+    private void Awake()
     {
-        applicationQuitting = true;
+        instance = this;
+                
+        if (instance.dontDestroyOnLoad)
+        {
+            DontDestroyOnLoad(instance);
+        }
     }
 
     // Handles WebVR data from browser
@@ -139,13 +145,13 @@ public class WebVRManager : MonoBehaviour
     // received start VR from WebVR browser
     public void OnStartVR()
     {
-        setVrState(WebVRState.ENABLED);
+        Instance.setVrState(WebVRState.ENABLED);        
     }
 
     // receive end VR from WebVR browser
     public void OnEndVR()
     {
-        setVrState(WebVRState.NORMAL);
+        Instance.setVrState(WebVRState.NORMAL);
     }
 
     // Latency test from browser
@@ -201,12 +207,7 @@ public class WebVRManager : MonoBehaviour
         public float[] orientation = null;
         public float[] position = null;
         public WebVRControllerButton[] buttons = new WebVRControllerButton[0];
-    }
-
-    void Awake()
-    {
-        instance = this;
-    }
+    }    
 
     void Start()
     {

--- a/Assets/WebVR/Scripts/WebVRManager.cs
+++ b/Assets/WebVR/Scripts/WebVRManager.cs
@@ -29,16 +29,47 @@ public class WebVRManager : MonoBehaviour
     public delegate void ControllerUpdate(int index, string hand, Vector3 position, Quaternion rotation, Matrix4x4 sitStand, WebVRControllerButton[] buttons);
     public static event ControllerUpdate OnControllerUpdate;
 
+    private static bool applicationQuitting = false;
+    
     public static WebVRManager Instance {
         get
         {
+            if (applicationQuitting)
+            {
+                Debug.LogWarning("[Singleton] Instance WebVRManager '"+
+                                 "' already destroyed on application quit." +
+                                 " Won't create again - returning null. Check your OnDestroy Code");
+                return null;
+            }
+            
             if (instance == null)
             {
-                GameObject go = new GameObject("WebVRManager");
-                go.AddComponent<WebVRManager>();
+                var managerInScene = FindObjectOfType<WebVRManager>();
+
+                var name = "WebVRManager (Singleton)";
+                
+                if (managerInScene != null)
+                {
+                    instance = managerInScene;
+                    instance.name = name;
+                }
+                else
+                {
+                    GameObject go = new GameObject(name);
+                    
+                    go.AddComponent<WebVRManager>();                    
+                }
+                
+                DontDestroyOnLoad(instance);
             }
+            
             return instance;
         }
+    }
+
+    private void OnDestroy()
+    {
+        applicationQuitting = true;
     }
 
     // Handles WebVR data from browser


### PR DESCRIPTION
Fixes some of the issues in #290

**Changes**

+ Changed the VRManager to follow the unity singleton pattern I've seen in my travels. It's a static instance that is referencing a game object created with DontDestroyOnLoad(gameobject). Singleton also checks if there is a gameobject of type VRManager in the scene before creating the itself. I think that should correct the double initialization issue the reporter was referencing in the issue.

+ I noticed the WebVRCamera wasn't removing itself from the OnHeadsetUpdate/OnVRChange events if the camera was disabled or destroyed. I think it might be better to deregister the camera from those events incase that happens... Although I doubt it's that common of a use case

+ I added some files to the gitignore for Jetbrains Rider files. 

**Doesn't Address**
> It's also not detecting the OnEndVR().
+ I haven't tackled this one quite yet. 
 